### PR TITLE
[codex] align site content with CV

### DIFF
--- a/src/content/work/discovery-health.md
+++ b/src/content/work/discovery-health.md
@@ -5,4 +5,6 @@ dateStart: "12/01/2007"
 dateEnd: "04/30/2013"
 ---
 
-Started my career here as a software developer. Worked here for about 5 and a half years in a team that was responsible for communication and content platforms. I primarily worked with Java, XSL and some proprietary technologies.
+Started my career in a template and content-generation role before moving into Java development.
+
+Worked on enterprise communication and messaging systems used across the Discovery group, building a foundation in Java, XSLT, integration-oriented systems, and production platform support.

--- a/src/content/work/fnb.md
+++ b/src/content/work/fnb.md
@@ -5,4 +5,6 @@ dateStart: "05/01/2013"
 dateEnd: "05/31/2016"
 ---
 
-Worked as senior Java developer on a team responsible for the bank's online sales and web platform.
+Worked as a senior Java developer on digital banking, online sales, and customer-facing web platforms.
+
+Contributed to backend development, architecture discussions, and delivery of major digital capabilities including public web platform work, online sales journeys, and supporting services in a large-scale banking environment.

--- a/src/content/work/investec.md
+++ b/src/content/work/investec.md
@@ -5,6 +5,6 @@ dateStart: "06/01/2016"
 dateEnd: "Current"
 ---
 
-Started as senior developer. Was later promoted to Technical lead on a team that's responsible for a client data platform.
+Progressed from senior developer to technical lead and then divisional engineering lead within Investec Specialist Bank.
 
-Was further promoted to position of engineering lead and am currently responsible for heading up engineering for a technology division within Investec Specialist Bank.
+My work has focused on client information systems, cloud-native platform design, Azure adoption, CI/CD improvement, and modernising legacy banking platforms. I now provide engineering leadership across multiple teams, supporting technical leads, shaping architecture and delivery practices, and helping teams make pragmatic technical decisions across cloud, platform, and software delivery work.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,23 +34,23 @@ const work = await Promise.all(
   <Container size="wide">
     <div class="animate mb-12 max-w-2xl">
       <div class="mb-3 text-sm font-semibold text-[color:var(--color-accent)]">
-        Engineering lead / software systems / practical delivery
+        Engineering leadership / cloud modernisation / practical delivery
       </div>
       <h4 class="text-heading text-3xl font-semibold leading-tight sm:text-4xl">
-        I build and lead software teams working on durable financial-services systems.
+        I lead software engineering teams building durable financial-services systems.
       </h4>
     </div>
     <div class="space-y-16">
       <section>
         <article class="max-w-2xl space-y-4">
           <p class="animate">
-            I am a South African software engineer and engineering lead with more than 15 years of experience turning complex business problems into reliable production systems.
+            I am a South African software engineering leader with more than 15 years of experience building, modernising, and operating business-critical systems in financial services.
           </p>
           <p class="animate">
-            My work sits mostly in banking and insurance, across Java, Kotlin, C#, CI/CD, Azure, and the engineering practices needed to keep teams moving with confidence.
+            My work spans backend engineering, cloud architecture, CI/CD, and engineering practices across Azure, C#, Java, and related platform technologies.
           </p>
           <p class="animate">
-            I currently head up engineering for a technology division at Investec, where the focus is technical direction, delivery quality, and building systems that age well.
+            I currently provide engineering leadership across multiple teams at Investec, helping shape technical direction, delivery quality, modernisation work, and practical enablement for developers and technical leads.
           </p>
         </article>
       </section>


### PR DESCRIPTION
## Summary

Updates the public site content to better align with the current professional CV while keeping the level of detail appropriate for a public-facing website.

## Changes

- Refreshes the homepage intro to focus on engineering leadership, cloud modernisation, financial-services systems, and practical delivery.
- Updates the Investec, FNB, and Discovery Health work entries with concise CV-aligned summaries.
- Keeps the existing content schema and navigation unchanged.

## Validation

- `npm run lint`
- `npm run build`
- `git diff --check`